### PR TITLE
Updated Gridware; beast v2.1.1 - added runtime dependency on java-ope…

### DIFF
--- a/apps/beast/2.1.1/metadata.yml
+++ b/apps/beast/2.1.1/metadata.yml
@@ -30,6 +30,10 @@
 :src_dir: BEAST
 :type: apps
 :version: '2.1.1'
+:dependencies:
+  :runtime:
+    el:
+      - java-openjdk
 :compilers:
   noarch:
 :compile: |


### PR DESCRIPTION
…njdk
