### PR TITLE
Updated Gridware; OpenFOAM v4.0.0 - Added zlib-devel to EL dependencies

### DIFF
--- a/apps/openfoam/4.0.0/metadata.yml
+++ b/apps/openfoam/4.0.0/metadata.yml
@@ -75,6 +75,7 @@
   gcc:
 :dependencies:
   el:
+    - zlib-devel
     - flex
     - mesa-libGL-devel
     - mesa-libGLU-devel


### PR DESCRIPTION
[ci skip]
