### PR TITLE
urlto fetch for mpfr

### DIFF
--- a/libs/mpfr/3.1.4/mpfr-3.1.4.tar.bz2.fetch
+++ b/libs/mpfr/3.1.4/mpfr-3.1.4.tar.bz2.fetch
@@ -1,1 +1,1 @@
-http://www.mpfr.org/mpfr-current/mpfr-3.1.4.tar.bz2
+https://ftp.gnu.org/gnu/mpfr/mpfr-3.1.4.tar.bz2


### PR DESCRIPTION
Hello

I was unable to gridware install mpfr 3.1.4 as the url pointed to mpfr-current which only has 3.1.5

url for mpfr pointed to mpfr-current which only has the current version, gnu has them all

Thanks

Neil