### PR TITLE
Updated Gridware; pdfkit v0.6.1 - ensure certifi library is extracted…

### DIFF
--- a/apps/pdfkit/0.6.1/metadata.yml
+++ b/apps/pdfkit/0.6.1/metadata.yml
@@ -31,9 +31,10 @@
   export PYTHONPATH=$PYTHONPATH:$PYTHONDEPSDIR
   export PYTHONDONTWRITEBYTECODE=true
   mkdir $PYTHONDEPSDIR
-  for a in chardet idna urllib3 certifi; do
+  for a in chardet idna urllib3; do
     easy_install --install-dir $PYTHONDEPSDIR $a <%= redirect(:python) %>
   done
+  easy_install -Z --install-dir $PYTHONDEPSDIR certifi <%= redirect(:python) %>
   python setup.py build <%= redirect(:build) %>
 :install: |
   PYTHONDEPSDIR=$(pwd)/python


### PR DESCRIPTION
… so cacert.pem can be accessible within the filesystem.